### PR TITLE
enable main_color to be initialized in definitions.h

### DIFF
--- a/Arduino/McLighting/McLighting.ino
+++ b/Arduino/McLighting/McLighting.ino
@@ -121,6 +121,7 @@ void setup() {
   strip.setBrightness(brightness);
   strip.setSpeed(ws2812fx_speed);
   //strip.setMode(FX_MODE_RAINBOW_CYCLE);
+  strip.setColor(main_color.red, main_color.green, main_color.blue);
   strip.start();
 
   // ***************************************************************************

--- a/Arduino/McLighting/definitions.h
+++ b/Arduino/McLighting/definitions.h
@@ -32,6 +32,6 @@ struct ledstate             // Data structure to store a state of a single led
    uint8_t blue;
 };
 
-typedef struct ledstate LEDState;   // Define the datatype LEDState
-LEDState ledstates[NUMLEDS];        // Get an array of led states to store the state of the whole strip
-LEDState main_color;                // Store the "main color" of the strip used in single color modes 
+typedef struct ledstate LEDState;    // Define the datatype LEDState
+LEDState ledstates[NUMLEDS];         // Get an array of led states to store the state of the whole strip
+LEDState main_color = { 255, 0, 0 }; // Store the "main color" of the strip used in single color modes 


### PR DESCRIPTION
For a special lamp I need the default mode and default color to be changed. The strip's main_color in ws2812fx modes seems to be red by default, although I have to confess that I didn't find the place where it's initialized.

With this patch it's still red, but the color is set with all the other configuration in definitions.h.

It may very well be possible that there's some other obvious way to do this, in which case I'd be glad to learn about that.