### PR TITLE
Set different colors

### DIFF
--- a/Arduino/McLighting/request_handlers.h
+++ b/Arduino/McLighting/request_handlers.h
@@ -96,9 +96,6 @@ void handleSetDifferentColors(uint8_t * mypayload) {
   while (nextCommand) {
     handleSetSingleLED(nextCommand, 0);
     nextCommand = (uint8_t*) strtok(NULL, "+");
-    delay(50);
-    Serial.print("Next command: ");
-    Serial.println((char*) nextCommand);
   }
 }
 


### PR DESCRIPTION
Added ability to set multiple different colors to specific LEDs using a single WS-Request.
Syntax: `+[LedNum][HexColor]+[LedNum][HexColor]+[LedNum][HexColor] [...]`

If this should get merged, [this issue](https://github.com/toblum/McLighting/issues/44) should probably be resolved first, because this feature relies on handleSetSingleLED().