### PR TITLE
added BUILTIN_LED for ESP-12F

### DIFF
--- a/Arduino/McLighting/definitions.h
+++ b/Arduino/McLighting/definitions.h
@@ -1,6 +1,7 @@
 // Neopixel
-#define PIN 5         // PIN where neopixel / WS2811 strip is attached
-#define NUMLEDS 24    // Number of leds in the strip
+#define PIN 5           // PIN where neopixel / WS2811 strip is attached
+#define NUMLEDS 24      // Number of leds in the strip
+//#define BUILTIN_LED 2   // ESP-12F has the built in LED on GPIO2, see https://github.com/esp8266/Arduino/issues/2192
 
 const char HOSTNAME[] = "ESP8266_01";   // Friedly hostname
 


### PR DESCRIPTION
As I'm using my own Neopixle Driver Board with an ESP-12F I've added the definition for GPIO2 where the built in LED is connected to on these boards.

See https://github.com/esp8266/Arduino/issues/2192