### PR TITLE
button press is published on mqtt

### DIFF
--- a/Arduino/McLighting/request_handlers.h
+++ b/Arduino/McLighting/request_handlers.h
@@ -606,7 +606,6 @@ void shortKeyPress() {
     #ifdef ENABLE_MQTT
         mqtt_client.publish(mqtt_outtopic, String("OK =off").c_str());
     #endif
-
   }
 }
 
@@ -617,7 +616,6 @@ void mediumKeyPress() {
   #ifdef ENABLE_MQTT
     mqtt_client.publish(mqtt_outtopic, String("OK =fire flicker").c_str());
   #endif
-
 }
 
 // called when button is kept pressed for 2 seconds or more
@@ -627,7 +625,6 @@ void longKeyPress() {
   #ifdef ENABLE_MQTT
     mqtt_client.publish(mqtt_outtopic, String("OK =fireworks random").c_str());
   #endif
-
 }
 
 void button() {

--- a/Arduino/McLighting/request_handlers.h
+++ b/Arduino/McLighting/request_handlers.h
@@ -597,9 +597,16 @@ void shortKeyPress() {
   if (buttonState == false) {
     setModeByStateString(BTN_MODE_SHORT);
     buttonState = true;
+	    #ifdef ENABLE_MQTT
+      mqtt_client.publish(mqtt_outtopic, String("OK =static white").c_str());
+    #endif
   } else {
     mode = OFF;
     buttonState = false;
+    #ifdef ENABLE_MQTT
+        mqtt_client.publish(mqtt_outtopic, String("OK =off").c_str());
+    #endif
+
   }
 }
 
@@ -607,12 +614,20 @@ void shortKeyPress() {
 void mediumKeyPress() {
   DBG_OUTPUT_PORT.printf("Medium button press\n");
   setModeByStateString(BTN_MODE_MEDIUM);
+  #ifdef ENABLE_MQTT
+    mqtt_client.publish(mqtt_outtopic, String("OK =fire flicker").c_str());
+  #endif
+
 }
 
 // called when button is kept pressed for 2 seconds or more
 void longKeyPress() {
   DBG_OUTPUT_PORT.printf("Long button press\n");
   setModeByStateString(BTN_MODE_LONG);
+  #ifdef ENABLE_MQTT
+    mqtt_client.publish(mqtt_outtopic, String("OK =fireworks random").c_str());
+  #endif
+
 }
 
 void button() {

--- a/Arduino/McLighting/request_handlers.h
+++ b/Arduino/McLighting/request_handlers.h
@@ -613,6 +613,7 @@ void shortKeyPress() {
 void mediumKeyPress() {
   DBG_OUTPUT_PORT.printf("Medium button press\n");
   setModeByStateString(BTN_MODE_MEDIUM);
+  buttonState = true;
   #ifdef ENABLE_MQTT
     mqtt_client.publish(mqtt_outtopic, String("OK =fire flicker").c_str());
   #endif
@@ -622,6 +623,7 @@ void mediumKeyPress() {
 void longKeyPress() {
   DBG_OUTPUT_PORT.printf("Long button press\n");
   setModeByStateString(BTN_MODE_LONG);
+  buttonState = true;
   #ifdef ENABLE_MQTT
     mqtt_client.publish(mqtt_outtopic, String("OK =fireworks random").c_str());
   #endif


### PR DESCRIPTION
previously the button press was not seen on mqtt - therefore local mode changes were not known to mqtt setups.
Now the button press action is also published to mqtt.
The published string looks the same like the mode was set via mqtt and is hardcoded - like the button modes. This could maybe improved - but I don't know how.
Also the buttonState was changed only for short press - now is also set to "on" when medium and long press occurs.