### PR TITLE
Updated Index.html

### DIFF
--- a/clients/web/build/index.htm
+++ b/clients/web/build/index.htm
@@ -8,6 +8,7 @@
 
 		<!--Let browser know website is optimized for mobile-->
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no"/>
+		<meta name="mobile-web-app-capable" content="yes">
 		<meta charset="utf-8"/>
 		<title>McLighting v2</title>
 	</head>


### PR DESCRIPTION
To add support for mobile to load as a WebApp.  With this change, when you go into Chrome mobile and click on "Add to homescreen", when the shortcut is launched instead of opening in your browser, it loads a completely separate WebApp which is viewed by the user as an entirely separate app inside the OS.  I'm still looking at how to change the app icon to a web referenced one but I have very, VERY limited HTML knowledge.  I know it involves `<link rel="icon" sizes="192x192" href="nice-highres.png">` but I'm still working on that one. The title of the app will be whatever is in the title field of the HTML file.  So, since i have two controllers at home, I edited the Title for each so they show up separately in the home screen.