### PR TITLE
Added #define ENABLE_MQTT_HOSTNAME_CHIPID, enabled by default

### DIFF
--- a/Arduino/McLighting/McLighting.ino
+++ b/Arduino/McLighting/McLighting.ino
@@ -413,24 +413,24 @@ void setup() {
   // Configure MQTT
   // ***************************************************************************
   #ifdef ENABLE_MQTT
-    if (mqtt_host != "" && String(mqtt_port).toInt() > 0) {
+    if (mqtt_host != "" && atoi(mqtt_port) > 0) {
       snprintf(mqtt_intopic, sizeof mqtt_intopic, "%s/in", HOSTNAME);
       snprintf(mqtt_outtopic, sizeof mqtt_outtopic, "%s/out", HOSTNAME);
 
       DBG_OUTPUT_PORT.printf("MQTT active: %s:%d\n", mqtt_host, String(mqtt_port).toInt());
 
-      mqtt_client.setServer(mqtt_host, String(mqtt_port).toInt());
+      mqtt_client.setServer(mqtt_host, atoi(mqtt_port));
       mqtt_client.setCallback(mqtt_callback);
     }
   #endif
 
   #ifdef ENABLE_AMQTT
-    if (mqtt_host != "" && String(mqtt_port).toInt() > 0) {
+    if (mqtt_host != "" && atoi(mqtt_port) > 0) {
       amqttClient.onConnect(onMqttConnect);
       amqttClient.onDisconnect(onMqttDisconnect);
       amqttClient.onMessage(onMqttMessage);
-      amqttClient.setServer(mqtt_host, String(mqtt_port).toInt());
-      amqttClient.setCredentials(mqtt_user, mqtt_pass);
+      amqttClient.setServer(mqtt_host, atoi(mqtt_port));
+      if (mqtt_user != "" or mqtt_pass != "") amqttClient.setCredentials(mqtt_user, mqtt_pass);
       amqttClient.setClientId(mqtt_clientid);
 
       connectToMqtt();

--- a/Arduino/McLighting/definitions.h
+++ b/Arduino/McLighting/definitions.h
@@ -58,7 +58,6 @@ uint32_t autoParams[][4] = { // color, speed, mode, duration (seconds)
   #endif
 
   #ifdef ENABLE_HOMEASSISTANT
-    //#define ENABLE_HA_HOSTNAME_CHIPID          // Uncomment/comment to add ESPChipID to end of HA hostname
     String mqtt_ha = "home/" + String(HOSTNAME) + "_ha/";
     String mqtt_ha_state_in = mqtt_ha + "state/in";
     String mqtt_ha_state_out = mqtt_ha + "state/out";

--- a/Arduino/McLighting/definitions.h
+++ b/Arduino/McLighting/definitions.h
@@ -58,6 +58,7 @@ uint32_t autoParams[][4] = { // color, speed, mode, duration (seconds)
   #endif
 
   #ifdef ENABLE_HOMEASSISTANT
+    //#define ENABLE_HA_HOSTNAME_CHIPID          // Uncomment/comment to add ESPChipID to end of HA hostname
     String mqtt_ha = "home/" + String(HOSTNAME) + "_ha/";
     String mqtt_ha_state_in = mqtt_ha + "state/in";
     String mqtt_ha_state_out = mqtt_ha + "state/out";
@@ -70,7 +71,13 @@ uint32_t autoParams[][4] = { // color, speed, mode, duration (seconds)
     uint16_t color_temp = 327; // min is 154 and max is 500
   #endif
 
-  const char mqtt_clientid[] = "NeoPixelsStrip"; // MQTT ClientID
+  #define ENABLE_MQTT_HOSTNAME_CHIPID          // Uncomment/comment to add ESPChipID to end of MQTT hostname
+  #ifdef ENABLE_MQTT_HOSTNAME_CHIPID
+    const char* mqtt_clientid = String(String(HOSTNAME) + "-" + String(ESP.getChipId())).c_str(); // MQTT ClientID
+  #else
+    const char* mqtt_clientid = HOSTNAME;          // MQTT ClientID
+  #endif
+
 
   char mqtt_host[64] = "";
   char mqtt_port[6] = "";

--- a/Arduino/McLighting/definitions.h
+++ b/Arduino/McLighting/definitions.h
@@ -70,7 +70,7 @@ uint32_t autoParams[][4] = { // color, speed, mode, duration (seconds)
     uint16_t color_temp = 327; // min is 154 and max is 500
   #endif
 
-  #define ENABLE_MQTT_HOSTNAME_CHIPID          // Uncomment/comment to add ESPChipID to end of MQTT hostname
+  //#define ENABLE_MQTT_HOSTNAME_CHIPID          // Uncomment/comment to add ESPChipID to end of MQTT hostname
   #ifdef ENABLE_MQTT_HOSTNAME_CHIPID
     const char* mqtt_clientid = String(String(HOSTNAME) + "-" + String(ESP.getChipId())).c_str(); // MQTT ClientID
   #else

--- a/Arduino/McLighting/request_handlers.h
+++ b/Arduino/McLighting/request_handlers.h
@@ -1044,11 +1044,7 @@ void webSocketEvent(uint8_t num, WStype_t type, uint8_t * payload, size_t lenght
           #ifdef MQTT_HOME_ASSISTANT_SUPPORT
             DynamicJsonBuffer jsonBuffer(JSON_ARRAY_SIZE(strip.getModeCount()) + JSON_OBJECT_SIZE(11));
             JsonObject& json = jsonBuffer.createObject();
-            #ifdef ENABLE_HA_HOSTNAME_CHIPID
-              json["name"] = String(String(HOSTNAME) + "-" + String(ESP.getChipId()));
-            #else
-              json["name"] = HOSTNAME;
-            #endif
+            json["name"] = HOSTNAME;
             json["platform"] = "mqtt_json";
             json["state_topic"] = mqtt_ha_state_out;
             json["command_topic"] = mqtt_ha_state_in;
@@ -1128,11 +1124,7 @@ void webSocketEvent(uint8_t num, WStype_t type, uint8_t * payload, size_t lenght
         #ifdef MQTT_HOME_ASSISTANT_SUPPORT
           DynamicJsonBuffer jsonBuffer(JSON_ARRAY_SIZE(strip.getModeCount()) + JSON_OBJECT_SIZE(11));
           JsonObject& json = jsonBuffer.createObject();
-          #ifdef ENABLE_HA_HOSTNAME_CHIPID
-            json["name"] = String(String(HOSTNAME) + "-" + String(ESP.getChipId()));
-          #else
-            json["name"] = HOSTNAME;
-          #endif
+          json["name"] = HOSTNAME;
           json["platform"] = "mqtt_json";
           json["state_topic"] = mqtt_ha_state_out;
           json["command_topic"] = mqtt_ha_state_in;

--- a/Arduino/McLighting/request_handlers.h
+++ b/Arduino/McLighting/request_handlers.h
@@ -1044,7 +1044,11 @@ void webSocketEvent(uint8_t num, WStype_t type, uint8_t * payload, size_t lenght
           #ifdef MQTT_HOME_ASSISTANT_SUPPORT
             DynamicJsonBuffer jsonBuffer(JSON_ARRAY_SIZE(strip.getModeCount()) + JSON_OBJECT_SIZE(11));
             JsonObject& json = jsonBuffer.createObject();
-            json["name"] = HOSTNAME;
+            #ifdef ENABLE_HA_HOSTNAME_CHIPID
+              json["name"] = String(String(HOSTNAME) + "-" + String(ESP.getChipId()));
+            #else
+              json["name"] = HOSTNAME;
+            #endif
             json["platform"] = "mqtt_json";
             json["state_topic"] = mqtt_ha_state_out;
             json["command_topic"] = mqtt_ha_state_in;
@@ -1124,7 +1128,11 @@ void webSocketEvent(uint8_t num, WStype_t type, uint8_t * payload, size_t lenght
         #ifdef MQTT_HOME_ASSISTANT_SUPPORT
           DynamicJsonBuffer jsonBuffer(JSON_ARRAY_SIZE(strip.getModeCount()) + JSON_OBJECT_SIZE(11));
           JsonObject& json = jsonBuffer.createObject();
-          json["name"] = HOSTNAME;
+          #ifdef ENABLE_HA_HOSTNAME_CHIPID
+            json["name"] = String(String(HOSTNAME) + "-" + String(ESP.getChipId()));
+          #else
+            json["name"] = HOSTNAME;
+          #endif
           json["platform"] = "mqtt_json";
           json["state_topic"] = mqtt_ha_state_out;
           json["command_topic"] = mqtt_ha_state_in;


### PR DESCRIPTION
By default, ChipID is attached to the HOSTNAME and used as clientID for MQTT.