### PR TITLE
v2.1.9

### DIFF
--- a/Arduino/McLighting/McLighting.ino
+++ b/Arduino/McLighting/McLighting.ino
@@ -53,8 +53,8 @@
 #endif
 
 #ifdef ARDUINOJSON_VERSION
-  #if !(ARDUINOJSON_VERSION_MAJOR == 6 and ARDUINOJSON_VERSION_MINOR == 6)
-    #error "Install ArduinoJson v6.6.0-beta"
+  #if !(ARDUINOJSON_VERSION_MAJOR == 6 and ARDUINOJSON_VERSION_MINOR == 7)
+    #error "Install ArduinoJson v6.7.0-beta"
   #endif
 #endif
 

--- a/Arduino/McLighting/request_handlers.h
+++ b/Arduino/McLighting/request_handlers.h
@@ -765,7 +765,7 @@ void webSocketEvent(uint8_t num, WStype_t type, uint8_t * payload, size_t lenght
     }
 
     void sendState() {
-      const size_t bufferSize = JSON_OBJECT_SIZE(3) + JSON_OBJECT_SIZE(6);
+      const size_t bufferSize = JSON_OBJECT_SIZE(3) + JSON_OBJECT_SIZE(6) + 500;
       DynamicJsonDocument jsonBuffer(bufferSize);
       JsonObject root = jsonBuffer.to<JsonObject>();
 
@@ -781,9 +781,9 @@ void webSocketEvent(uint8_t num, WStype_t type, uint8_t * payload, size_t lenght
 
       root["speed"] = ws2812fx_speed;
 
-      char modeName[30];
-      strncpy_P(modeName, (PGM_P)strip.getModeName(strip.getMode()), sizeof(modeName)); // copy from progmem
-      root["effect"] = modeName;
+      //char modeName[30];
+      //strncpy_P(modeName, (PGM_P)strip.getModeName(strip.getMode()), sizeof(modeName)); // copy from progmem
+      root["effect"] = strip.getModeName(strip.getMode());
 
       char buffer[measureJson(root) + 1];
       serializeJson(root, buffer, sizeof(buffer));
@@ -1203,7 +1203,7 @@ bool writeConfigFS(bool saveConfig){
     json["mqtt_user"] = mqtt_user;
     json["mqtt_pass"] = mqtt_pass;
   
-//      SPIFFS.remove("/config.json") ? DBG_OUTPUT_PORT.println("removed file") : DBG_OUTPUT_PORT.println("failed removing file");
+    //SPIFFS.remove("/config.json") ? DBG_OUTPUT_PORT.println("removed file") : DBG_OUTPUT_PORT.println("failed removing file");
     File configFile = SPIFFS.open("/config.json", "w");
     if (!configFile) DBG_OUTPUT_PORT.println("failed to open config file for writing");
 
@@ -1275,7 +1275,7 @@ bool writeStateFS(){
   json["green"] = main_color.green;
   json["blue"] = main_color.blue;
 
-//      SPIFFS.remove("/state.json") ? DBG_OUTPUT_PORT.println("removed file") : DBG_OUTPUT_PORT.println("failed removing file");
+  //SPIFFS.remove("/stripstate.json") ? DBG_OUTPUT_PORT.println("removed file") : DBG_OUTPUT_PORT.println("failed removing file");
   File configFile = SPIFFS.open("/stripstate.json", "w");
   if (!configFile) {
     DBG_OUTPUT_PORT.println("Failed!");

--- a/Arduino/McLighting/version.h
+++ b/Arduino/McLighting/version.h
@@ -1,1 +1,1 @@
-#define SKETCH_VERSION "2.1.8" 
+#define SKETCH_VERSION "2.1.9" 

--- a/Arduino/McLighting/version_info.ino
+++ b/Arduino/McLighting/version_info.ino
@@ -35,4 +35,10 @@
  * 11 Dec 2018 v 2.1.8
  * - Fix Auto-Discovery for HA version >= 0.84 #286
  * - Fix #283
+ * 
+ * 13 Dec 2018 v 2.1.9
+ * - HA is not getting the correct animation name being run, boils down to changes to ArduinoJson library
+ * - Bump ArduinoJson library requirment for v6.7.0-beta (better memory management)
+ * - sendState() needs extra memory for jsonBuffer
+ * - sensState() effect can be sent directly instead of copying from PROGMEM
  */


### PR DESCRIPTION
- sendState() needs extra memory for jsonBuffer
- sensState() effect can be sent directly instead of copying from PROGMEM
- Bump ArduinoJson library requirment for v6.7.0-beta (better memory management)
- Update version
- Update version info