### PR TITLE
Use milliseconds for autocycle

### DIFF
--- a/Arduino/McLighting/definitions.h
+++ b/Arduino/McLighting/definitions.h
@@ -54,7 +54,7 @@ const char HOSTNAME[] = "McLighting01";   // Friedly hostname
 #endif
 
 // parameters for automatically cycling favorite patterns
-uint32_t autoParams[][4] = { // color, speed, mode, duration (milliseconds)
+uint32_t autoParams[][4] = {  // color, speed, mode, duration (milliseconds)
   {0xff0000, 200,  1,  5000}, // blink red for 5 seconds
   {0x00ff00, 200,  3, 10000}, // wipe green for 10 seconds
   {0x0000ff, 200, 14,  5000}, // dual scan blue for 5 seconds

--- a/Arduino/McLighting/definitions.h
+++ b/Arduino/McLighting/definitions.h
@@ -54,11 +54,11 @@ const char HOSTNAME[] = "McLighting01";   // Friedly hostname
 #endif
 
 // parameters for automatically cycling favorite patterns
-uint32_t autoParams[][4] = { // color, speed, mode, duration (seconds)
-  {0xff0000, 200,  1,  5.0}, // blink red for 5 seconds
-  {0x00ff00, 200,  3, 10.0}, // wipe green for 10 seconds
-  {0x0000ff, 200, 11,  5.0}, // dual scan blue for 5 seconds
-  {0x0000ff, 200, 42, 15.0}  // fireworks for 15 seconds
+uint32_t autoParams[][4] = { // color, speed, mode, duration (milliseconds)
+  {0xff0000, 200,  1,  5000}, // blink red for 5 seconds
+  {0x00ff00, 200,  3, 10000}, // wipe green for 10 seconds
+  {0x0000ff, 200, 14,  5000}, // dual scan blue for 5 seconds
+  {0x0000ff, 200, 45, 15000}  // fireworks for 15 seconds
 };
 
 #if defined(ENABLE_MQTT) or defined(ENABLE_AMQTT)

--- a/Arduino/McLighting/request_handlers.h
+++ b/Arduino/McLighting/request_handlers.h
@@ -428,9 +428,8 @@ void autoTick() {
   strip->setColor(autoParams[autoCount][0]);
   strip->setSpeed(convertSpeed((uint8_t)autoParams[autoCount][1]));
   strip->setMode((uint8_t)autoParams[autoCount][2]);
-  autoTicker.once((float)autoParams[autoCount][3], autoTick);
-  DBG_OUTPUT_PORT.print("autoTick ");
-  DBG_OUTPUT_PORT.println(autoCount);
+  autoTicker.once_ms((uint32_t)autoParams[autoCount][3], autoTick);
+  DBG_OUTPUT_PORT.printf("autoTick[%d]: {0x%06x, %d, %d, %d}\n", autoCount, autoParams[autoCount][0], (uint8_t)autoParams[autoCount][1], (uint8_t)autoParams[autoCount][2], (uint32_t)autoParams[autoCount][3]);
 
   autoCount++;
   if (autoCount >= (sizeof(autoParams) / sizeof(autoParams[0]))) autoCount = 0;


### PR DESCRIPTION
Switching to milliseconds allows the user more precise control over autocycling, but the current implementation does not allow partial seconds.

*The [Autocycling](https://github.com/toblum/McLighting/wiki/Autocycling) wiki page also needs to be updated to reflect these changes after merging:*

```markdown
Starting from 30.09.2017 there is now a way to auto cycle through the modes. In `definitions.h` you can define what modes are cycled through:

    // parameters for automatically cycling favorite patterns
    uint32_t autoParams[][4] = {  // color, speed, mode, duration (milliseconds)
      {0xff0000, 200,  1,  5000}, // blink red for 5 seconds
      {0x00ff00, 200,  3, 10000}, // wipe green for 10 seconds
      {0x0000ff, 200, 14,  5000}, // dual scan blue for 5 seconds
      {0x0000ff, 200, 45, 15000}  // fireworks for 15 seconds
    };

You can get the mode numbers from the browser frontend. Just add/modify lines how you like it.
```