### PR TITLE
Add tls support to amqtt

### DIFF
--- a/Arduino/McLighting/McLighting.ino
+++ b/Arduino/McLighting/McLighting.ino
@@ -544,6 +544,12 @@ void setup() {
       if (mqtt_user != "" or mqtt_pass != "") amqttClient.setCredentials(mqtt_user, mqtt_pass);
       amqttClient.setClientId(mqtt_clientid);
       amqttClient.setWill(mqtt_will_topic, 2, true, mqtt_will_payload, 0);
+#if ASYNC_TCP_SSL_ENABLED
+      amqttClient.setSecure(MQTT_SECURE);
+      if (MQTT_SECURE) {
+        amqttClient.addServerFingerprint((const uint8_t[])MQTT_SERVER_FINGERPRINT);
+      }
+#endif
 
       connectToMqtt();
     }
@@ -639,6 +645,14 @@ void setup() {
     #endif
     #ifdef ENABLE_MQTT
       json["mqtt"] = "ON";
+    #endif
+    #if defined(ENABLE_MQTT) or defined(ENABLE_AMQTT)
+      json["mqtt_host"] = mqtt_host;
+      json["mqtt_port"] = mqtt_port;
+      json["mqtt_user"] = mqtt_user;
+      #if ASYNC_TCP_SSL_ENABLED
+        json["mqtt_tls"] = (MQTT_SECURE ? "ON" : "OFF");
+      #endif
     #endif
     #ifdef ENABLE_HOMEASSISTANT
       json["home_assistant"] = "ON";

--- a/Arduino/McLighting/definitions.h
+++ b/Arduino/McLighting/definitions.h
@@ -38,6 +38,11 @@
   uint8_t _sn[4] = {255,255,255,0};
 #endif
 
+#if ASYNC_TCP_SSL_ENABLED
+  #define MQTT_SECURE true
+  #define MQTT_SERVER_FINGERPRINT {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44}
+#endif
+
 #ifdef MQTT_HOME_ASSISTANT_SUPPORT
   #define MQTT_HOME_ASSISTANT_0_87_SUPPORT // Comment if using HA version < 0.87
 #endif


### PR DESCRIPTION
Enable by setting `-D ASYNC_TCP_SSL_ENABLED=1` as build flag.
The addition to `/esp_status` turned out to be usefull for debugging so i've included it.

Tested on NodeMCU with mosquitto.

To retrieve the fingerprint you can run 
``` bash
openssl s_client -connect <host>:<port> < /dev/null 2>/dev/null | openssl x509 -fingerprint -noout -in /dev/stdin
``` 